### PR TITLE
Update EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 indent_size = 2
 indent_style = space
 insert_final_newline = true


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.editorconfig` file to modify the end-of-line character setting.

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bL5-R5): Changed `end_of_line` from `lf` to `crlf` to standardize line endings across the project.