### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,19 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to streamline dependency updates for GitHub Actions. The most significant changes include restructuring the directory specification, adding a timezone for scheduling, and refining the group configuration for updates.

### Updates to Dependabot configuration:

* Consolidated the `directories` field into a single `directory` field to simplify the configuration. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Added a `timezone` field set to `"Europe/London"` to ensure the cron schedule aligns with the specified time zone. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Enhanced the `github-actions` group configuration:
  - Introduced an `applies-to` field with the value `"version-updates"` for more precise targeting. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
  - Added `exclude-patterns` to exclude updates matching `"super-linter/*"`. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)