### PR TITLE
Update Dependabot Configuration for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
           - "*"
         exclude-patterns:
           - "super-linter/*"
+          - "JackPlowman/reusable-workflows/*"
         update-types:
           - "patch"
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/*"
+          - "super-linter/super-linter"
           - "JackPlowman/reusable-workflows/*"
         update-types:
           - "patch"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `updates` section of the `.github/dependabot.yml` file to refine the exclusion patterns for dependencies.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R18): Adjusted the `exclude-patterns` to specifically exclude `super-linter/super-linter` instead of `super-linter/*` and added a new exclusion for `JackPlowman/reusable-workflows/*`.