### PR TITLE
Migrate Sync Labels to Common Sync Labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,4 +17,4 @@ jobs:
       pull-requests: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
     secrets:
-      workflow_github_token: ${{ secrets.GH_TOKEN }}
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,25 +6,15 @@ on:
       - main
     paths:
       - .github/other-configurations/labels.yml
+  workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   configure-labels:
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Sync labels
-        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          manifest: .github/other-configurations/labels.yml
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1fc46e17341e1306bfff74123efac880aff16d48 # v2025.05.17.04
+    secrets:
+      workflow_github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/sync-labels.yml` file to simplify and modernize the workflow configuration. The key changes include enabling manual workflow dispatch, updating permissions, and replacing inline job definitions with a reusable workflow.

### Workflow improvements:

* Added support for manual triggering of the workflow using the `workflow_dispatch` event.
* Updated `permissions` to use an empty object `{}` at the workflow level and defined specific permissions (`contents: read`, `pull-requests: write`) at the job level for better security and clarity.
* Replaced the inline job definition for `configure-labels` with a reusable workflow from `JackPlowman/reusable-workflows`. This simplifies the configuration and centralizes logic.