### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ My dotfiles for Windows. As well as scripts, aliases, and other tools to make my
   - [Table of Contents](#table-of-contents)
   - [Project Structure](#project-structure)
   - [Contributing](#contributing)
-  - [License](#license)
+  - [Licence](#licence)
 
 ## Project Structure
 
@@ -26,6 +26,6 @@ development-environment - directory gets copied to the home directory
 
 We welcome contributions to the project. Please read the [Contributing Guidelines](docs/CONTRIBUTING.md) for more information.
 
-## License
+## Licence
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT Licence. See the [LICENCE](LICENCE) file for details.


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the project to use British English spelling for "Licence" instead of the American English "License" throughout the documentation and configuration files. The most important changes are:

Documentation updates:

* Updated all references from "License" to "Licence" in the `README.md`, including section headers and links to the file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R31)

Configuration update:

* Changed the file pattern in `.github/other-configurations/labeller.yml` from `LICENSE` to `LICENCE` to match the new file naming convention.