### PR TITLE
Add GitHub Workflow permission notes

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 env:
   FORCE_COLOR: 1
@@ -20,9 +19,9 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      actions: read
-      pull-requests: write
-      security-events: write
+      actions: read # Allow the workflow to read actions metadata
+      pull-requests: write # Allow the workflow to create and modify pull request comments
+      security-events: write # Allow the workflow to upload analysis results
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +30,7 @@ jobs:
     name: CodeQL Analysis
     permissions:
       contents: read
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     strategy:
       matrix:
         language: [actions]

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -10,7 +10,7 @@ jobs:
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:
-      pull-requests: write
+      pull-requests: write # For writing labels and comments on PRs
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Configure Labels
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # For writing labels to the repository
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to clarify the purpose of specific permission settings by adding explanatory comments. No functional changes are made; these updates are purely for documentation and maintainability.

Permissions documentation improvements:

* Added comments explaining the purpose of each permission in the `Common Code Checks` job in `.github/workflows/code-checks.yml`, making it clear why each permission is required.
* Added a comment to the `security-events: write` permission in the `CodeQL Analysis` job in `.github/workflows/code-checks.yml` to clarify its use for uploading analysis results.
* Added a comment to the `pull-requests: write` permission in the `common-pull-request-tasks` job in `.github/workflows/pull-request-tasks.yml` to indicate it is used for writing labels and comments on PRs.
* Added a comment to the `pull-requests: write` permission in the `Configure Labels` job in `.github/workflows/sync-labels.yml` to specify it is for writing labels to the repository.

Other minor cleanup:

* Removed the unused `packages: read` permission from the top-level permissions in `.github/workflows/code-checks.yml`.