### PR TITLE
Add zoxide

### DIFF
--- a/development-environment/.bashrc
+++ b/development-environment/.bashrc
@@ -42,9 +42,6 @@ plugins=(
 source "$OSH"/oh-my-bash.sh
 
 # ------------------------------------------------------------------------#
-# Aliases
-alias reload="source ~/.bashrc"
-alias pretty="prettier . --check --write"
 # Aliases for Development Scripts
 alias commit="bash ~/scripts/commit_and_push.sh"
 alias update="bash ~/scripts/update_and_push.sh"
@@ -57,4 +54,11 @@ alias box="bash ~/scripts/box.sh"
 # ------------------------------------------------------------------------#
 # Tools
 
+eval "$(zoxide init bash)"
 eval "$(oh-my-posh init bash --config ~/oh-my-posh.json)"
+
+# ------------------------------------------------------------------------#
+# Command Aliases
+alias reload="source ~/.bashrc"
+alias pretty="prettier . --check --write"
+alias cd=z


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `development-environment/.bashrc` file to improve developer productivity and streamline navigation. The most important changes include reorganizing and expanding command aliases, and adding initialization for the `zoxide` tool.

**Shell navigation improvements:**

* Added initialization for `zoxide` to enable fast directory jumping (`eval "$(zoxide init bash)"`).
* Added an alias for `cd` to use `z`, leveraging `zoxide` for smarter directory changes (`alias cd=z`).

**Command alias reorganization:**

* Moved and grouped command aliases into a dedicated section for clarity.
* Restored previously removed aliases for `reload` and `pretty`, making them easier to find and use (`alias reload="source ~/.bashrc"`, `alias pretty="prettier . --check --write"`). [[1]](diffhunk://#diff-720dffb230eddc170da91e87acc8112d914c37ff95efdb17898c92dc7c28c238L45-L47) [[2]](diffhunk://#diff-720dffb230eddc170da91e87acc8112d914c37ff95efdb17898c92dc7c28c238R57-R64)