### PR TITLE
Add warp launch configuration

### DIFF
--- a/warp_launch_configurations/dev.yaml
+++ b/warp_launch_configurations/dev.yaml
@@ -8,7 +8,7 @@
 # More on how to do so here:
 # https://docs.warp.dev/features/sessions/launch-configurations
 #
-# All launch configurations are stored under C:\Users\Jackl\AppData\Roaming\warp\Warp\data\launch_configurations.
+# All launch configurations are stored under %APPDATA%\warp\Warp\data\launch_configurations (Windows) or <USER_HOME>/AppData/Roaming/warp/Warp/data/launch_configurations (cross-platform).
 # Edit them anytime!
 #
 # You can also add commands that run on-start for your launch configurations like so:

--- a/warp_launch_configurations/dev.yaml
+++ b/warp_launch_configurations/dev.yaml
@@ -1,0 +1,38 @@
+# Warp Launch Configuration
+#
+#
+# Use this to start a certain configuration of windows, tabs, and panes.
+# Open the launch configuration palette to access and open any launch configuration.
+#
+# This file defines your launch configuration.
+# More on how to do so here:
+# https://docs.warp.dev/features/sessions/launch-configurations
+#
+# All launch configurations are stored under C:\Users\Jackl\AppData\Roaming\warp\Warp\data\launch_configurations.
+# Edit them anytime!
+#
+# You can also add commands that run on-start for your launch configurations like so:
+# ---
+# name: Example with Command
+# windows:
+#  - tabs:
+#      - layout:
+#          cwd: /Users/warp-user/project
+#          commands:
+#            - exec: code .
+
+---
+name: Dev
+active_window_index: 0
+windows:
+  - active_tab_index: 0
+    tabs:
+      - layout:
+          cwd: /c/Users/Jackl/projects
+          is_focused: true
+      - layout:
+          cwd: /c/Users/Jackl/projects/RepoOrchestrator
+          is_focused: true
+      - layout:
+          cwd: /c/Users/Jackl/projects/RepoOrchestratorState
+          is_focused: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new launch configuration for Warp in the `warp_launch_configurations/dev.yaml` file. The configuration sets up multiple windows and tabs with predefined working directories to streamline the development workflow.

Development environment setup:

* Added a `Dev` launch configuration that opens three tabs, each with a different working directory: `projects`, `RepoOrchestrator`, and `RepoOrchestratorState`, all set as focused tabs.
* Included documentation and usage instructions at the top of the configuration file to guide users on customizing and using Warp launch configurations.