### PR TITLE
Disable Zoxide Warning

### DIFF
--- a/development-environment/.bashrc
+++ b/development-environment/.bashrc
@@ -42,6 +42,10 @@ plugins=(
 source "$OSH"/oh-my-bash.sh
 
 # ------------------------------------------------------------------------#
+# Environment settings
+export _ZO_DOCTOR=0
+
+# ------------------------------------------------------------------------#
 # Aliases for Development Scripts
 alias commit="bash ~/scripts/commit_and_push.sh"
 alias update="bash ~/scripts/update_and_push.sh"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new environment variable setting to the `.bashrc` configuration for the development environment.

Environment settings:

* Added `export _ZO_DOCTOR=0` to disable the `zoxide` doctor check.